### PR TITLE
feat: add vision support and dynamic context length based on model capabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lmstudio-copilot-provider",
-  "version": "0.1.1",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lmstudio-copilot-provider",
-      "version": "0.1.1",
+      "version": "0.1.7",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -1111,6 +1111,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -1570,6 +1571,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2669,6 +2671,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6440,6 +6443,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/lmstudio-client.ts
+++ b/src/lmstudio-client.ts
@@ -4,6 +4,7 @@ import {
   LMStudioModel,
   LMStudioRawModel,
   ChatMessage,
+  ChatMessageContentPart,
   ChatCompletionRequest,
   ChatCompletionChunk,
   ChatTool,
@@ -444,7 +445,11 @@ export class LMStudioClient {
   private normalizeOutgoingMessages(messages: ChatMessage[]): ChatMessage[] {
     return messages.map((m) => {
       const sanitized = this.sanitizeOutgoingContent(m.content);
-      const assistantToolCallOnly = m.role === 'assistant' && Boolean(m.tool_calls?.length) && !sanitized;
+      
+      // OpenAI (and thus LM Studio) requires content to be null when assistant has tool_calls
+      // If sanitized is an empty string or empty array, treat it as null.
+      const isEmpty = !sanitized || (Array.isArray(sanitized) && sanitized.length === 0) || (typeof sanitized === 'string' && sanitized.trim() === '');
+      const assistantToolCallOnly = m.role === 'assistant' && Boolean(m.tool_calls?.length) && isEmpty;
 
       return {
         ...m,
@@ -453,8 +458,22 @@ export class LMStudioClient {
     });
   }
 
-  private sanitizeOutgoingContent(content: string | null): string | null {
+  private sanitizeOutgoingContent(content: string | ChatMessageContentPart[] | null): string | ChatMessageContentPart[] | null {
     if (content === null) return null;
+    if (Array.isArray(content)) {
+      return content.map(part => {
+        if (part.type === 'text') {
+          return {
+            ...part,
+            text: part.text
+              .replace(/<\|(startofstream|endofstream|im_start|im_end|endoftext|end_of_turn|eot_id)\|>/g, '')
+              .replace(/<\/?(tool_response|tool_call)>/g, '')
+              .trim()
+          };
+        }
+        return part;
+      });
+    }
     return content
       .replace(/<\|(startofstream|endofstream|im_start|im_end|endoftext|end_of_turn|eot_id)\|>/g, '')
       .replace(/<\/?(tool_response|tool_call)>/g, '')

--- a/src/lmstudio-provider.ts
+++ b/src/lmstudio-provider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { LMStudioClient } from './lmstudio-client';
-import { LMStudioModel, ChatMessage, ChatTool } from './types';
+import { LMStudioModel, ChatMessage, ChatTool, ChatMessageContentPart } from './types';
 
 /**
  * Information about an LM Studio model for VS Code
@@ -89,12 +89,12 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
       name: this.formatModelName(model.id),
       family: 'lmstudio',
       version: '1.0.0',
-      maxInputTokens,
+      maxInputTokens: model.max_context_length || maxInputTokens,
       maxOutputTokens,
       lmstudioModelId: model.id,
       capabilities: {
         toolCalling: enableToolCalling,
-        imageInput: false,
+        imageInput: model.capabilities?.vision ?? false,
       },
     }));
   }
@@ -310,6 +310,7 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
    *   - LanguageModelTextPart → plain text
    *   - LanguageModelToolCallPart → an assistant's tool call request
    *   - LanguageModelToolResultPart → the result of a tool execution
+   *   - LanguageModelDataPart → an image or other binary data (for vision models)
    *
    * We flat-map because one VS Code message may expand into multiple OpenAI
    * messages (e.g. a user message with tool results → one "tool" message per result).
@@ -367,14 +368,45 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
         }
       }
 
-      // ── Plain message ────────────────────────────────────────────────
+      // ── Plain message (User/Assistant/System) ────────────────────────
       result.push({
         role: this.mapRole(msg.role),
-        content: this.extractMessageContent(msg),
+        content: this.convertToChatMessageContent(msg.content),
       });
     }
 
     return result;
+  }
+
+  /**
+   * Convert VS Code message content parts to OpenAI-compatible content.
+   * Handles text and images (vision).
+   */
+  private convertToChatMessageContent(
+    content: string | readonly any[]
+  ): string | ChatMessageContentPart[] {
+    if (typeof content === 'string') return content;
+
+    const parts: ChatMessageContentPart[] = [];
+    for (const part of content) {
+      if (part instanceof vscode.LanguageModelTextPart) {
+        parts.push({ type: 'text', text: part.value });
+      } else if (part instanceof vscode.LanguageModelDataPart && part.mimeType.startsWith('image/')) {
+        const base64 = Buffer.from(part.data).toString('base64');
+        parts.push({
+          type: 'image_url',
+          image_url: { url: `data:${part.mimeType};base64,${base64}` }
+        });
+      }
+    }
+
+    // If it's just one text part, return it as a string for better compatibility
+    // with models that don't fully support the array-of-parts format for plain text.
+    if (parts.length === 1 && parts[0].type === 'text') {
+      return parts[0].text;
+    }
+
+    return parts;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,10 +61,17 @@ export interface ModelsResponse {
 export interface ChatMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
   // null is required by OpenAI spec when the assistant message only contains tool_calls
-  content: string | null;
+  content: string | ChatMessageContentPart[] | null;
   tool_call_id?: string;
   tool_calls?: ToolCall[];
 }
+
+/**
+ * Content part for multi-modal messages
+ */
+export type ChatMessageContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: { url: string } };
 
 /**
  * Tool definition for function calling


### PR DESCRIPTION
**Summary**                                                                  
 This PR adds support for vision models and dynamic context length        
 reporting for LM Studio models.                                          
                                                                          
 **Changes**                                                                  
  - src/types.ts: Updated LMStudioModel to include capabilities.vision and
    max_context_length. Updated ChatMessage and added                     
    ChatMessageContentPart to support multi-modal content.                
  - src/lmstudio-client.ts: Updated normalizeOutgoingMessages and         
    sanitizeOutgoingContent to handle multi-modal content (text and       
    images).                                                              
  - src/lmstudio-provider.ts:                                             
      - Enabled imageInput capability based on the model's vision         
        capability.                                                       
      - Set maxInputTokens dynamically using the model's                  
        max_context_length (falling back to global config).               
      - Added convertToChatMessageContent to transform VS Code's          
        LanguageModelDataPart (images) into OpenAI-compatible image_url   
        format.                                                           
      - Updated convertMessages to use the new multi-modal content        
        conversion.