### PR TITLE
fix: improve multi-modal content handling and fix edge cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lmstudio-copilot-provider",
-  "version": "0.1.1",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lmstudio-copilot-provider",
-      "version": "0.1.1",
+      "version": "0.1.7",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -1111,6 +1111,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -1570,6 +1571,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2669,6 +2671,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6440,6 +6443,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/lmstudio-client.ts
+++ b/src/lmstudio-client.ts
@@ -4,6 +4,7 @@ import {
   LMStudioModel,
   LMStudioRawModel,
   ChatMessage,
+  ChatMessageContentPart,
   ChatCompletionRequest,
   ChatCompletionChunk,
   ChatTool,
@@ -444,7 +445,11 @@ export class LMStudioClient {
   private normalizeOutgoingMessages(messages: ChatMessage[]): ChatMessage[] {
     return messages.map((m) => {
       const sanitized = this.sanitizeOutgoingContent(m.content);
-      const assistantToolCallOnly = m.role === 'assistant' && Boolean(m.tool_calls?.length) && !sanitized;
+      
+      // OpenAI (and thus LM Studio) requires content to be null when assistant has tool_calls
+      // If sanitized is an empty string or empty array, treat it as null.
+      const isEmpty = !sanitized || (Array.isArray(sanitized) && sanitized.length === 0) || (typeof sanitized === 'string' && sanitized.trim() === '');
+      const assistantToolCallOnly = m.role === 'assistant' && Boolean(m.tool_calls?.length) && isEmpty;
 
       return {
         ...m,
@@ -453,8 +458,22 @@ export class LMStudioClient {
     });
   }
 
-  private sanitizeOutgoingContent(content: string | null): string | null {
+  private sanitizeOutgoingContent(content: string | ChatMessageContentPart[] | null): string | ChatMessageContentPart[] | null {
     if (content === null) return null;
+    if (Array.isArray(content)) {
+      return content.map(part => {
+        if (part.type === 'text') {
+          return {
+            ...part,
+            text: part.text
+              .replace(/<\|(startofstream|endofstream|im_start|im_end|endoftext|end_of_turn|eot_id)\|>/g, '')
+              .replace(/<\/?(tool_response|tool_call)>/g, '')
+              .trim()
+          };
+        }
+        return part;
+      });
+    }
     return content
       .replace(/<\|(startofstream|endofstream|im_start|im_end|endoftext|end_of_turn|eot_id)\|>/g, '')
       .replace(/<\/?(tool_response|tool_call)>/g, '')

--- a/src/lmstudio-client.ts
+++ b/src/lmstudio-client.ts
@@ -443,36 +443,48 @@ export class LMStudioClient {
   }
 
   private normalizeOutgoingMessages(messages: ChatMessage[]): ChatMessage[] {
-    return messages.map((m) => {
-      const sanitized = this.sanitizeOutgoingContent(m.content);
-      
-      // OpenAI (and thus LM Studio) requires content to be null when assistant has tool_calls
-      // If sanitized is an empty string or empty array, treat it as null.
-      const isEmpty = !sanitized || (Array.isArray(sanitized) && sanitized.length === 0) || (typeof sanitized === 'string' && sanitized.trim() === '');
-      const assistantToolCallOnly = m.role === 'assistant' && Boolean(m.tool_calls?.length) && isEmpty;
+    return messages
+      .map((m) => {
+        const sanitized = this.sanitizeOutgoingContent(m.content);
+        const empty = this.isContentEmpty(sanitized);
 
-      return {
-        ...m,
-        content: assistantToolCallOnly ? null : sanitized,
-      };
-    });
+        if (m.role === 'assistant' && m.tool_calls?.length) {
+          return { ...m, content: empty ? null : sanitized };
+        }
+
+        // Drop messages that are empty (unless it's an assistant with tool_calls)
+        if (empty) return null;
+
+        return { ...m, content: sanitized };
+      })
+      .filter((m): m is ChatMessage => m !== null);
+  }
+
+  private isContentEmpty(content: string | ChatMessageContentPart[] | null): boolean {
+    if (!content) return true;
+    if (typeof content === 'string') return content.trim().length === 0;
+    if (Array.isArray(content)) {
+      if (content.length === 0) return true;
+      return content.every(part => part.type === 'text' && part.text.trim().length === 0);
+    }
+    return false;
   }
 
   private sanitizeOutgoingContent(content: string | ChatMessageContentPart[] | null): string | ChatMessageContentPart[] | null {
     if (content === null) return null;
     if (Array.isArray(content)) {
-      return content.map(part => {
-        if (part.type === 'text') {
-          return {
-            ...part,
-            text: part.text
+      return content
+        .map(part => {
+          if (part.type === 'text') {
+            const cleaned = part.text
               .replace(/<\|(startofstream|endofstream|im_start|im_end|endoftext|end_of_turn|eot_id)\|>/g, '')
               .replace(/<\/?(tool_response|tool_call)>/g, '')
-              .trim()
-          };
-        }
-        return part;
-      });
+              .trim();
+            return { ...part, text: cleaned };
+          }
+          return part;
+        })
+        .filter(part => part.type !== 'text' || part.text.length > 0);
     }
     return content
       .replace(/<\|(startofstream|endofstream|im_start|im_end|endoftext|end_of_turn|eot_id)\|>/g, '')

--- a/src/lmstudio-provider.ts
+++ b/src/lmstudio-provider.ts
@@ -294,8 +294,26 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
     text: string | vscode.LanguageModelChatRequestMessage,
     _token: vscode.CancellationToken
   ): Promise<number> {
-    const content = typeof text === 'string' ? text : this.extractMessageContent(text);
-    return Math.ceil(content.length / 4);
+    if (typeof text === 'string') {
+      return Math.ceil(text.length / 4);
+    }
+    
+    const converted = this.convertToChatMessageContent(text.content);
+    let length = 0;
+    if (typeof converted === 'string') {
+      length = converted.length;
+    } else if (Array.isArray(converted)) {
+      for (const part of converted) {
+        if (part.type === 'text') {
+          length += part.text.length;
+        } else if (part.type === 'image_url') {
+          // Heuristic: images take significant context, often ~1000 tokens or more.
+          // Since we don't have the exact model's tokenisation for images, we use a constant.
+          length += 4000; 
+        }
+      }
+    }
+    return Math.ceil(length / 4);
   }
 
   // ──────────────────────────────────────────────────────────────────────
@@ -333,10 +351,10 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
             tool_call_id: part.callId,
           });
         }
-        // Include any accompanying plain text as a separate user message
-        const text = this.extractMessageContent(msg);
-        if (text.trim()) {
-          result.push({ role: 'user', content: text });
+        // Include any accompanying content (text/images) as a separate user message
+        const userContent = this.convertToChatMessageContent(msg.content);
+        if (!this.isContentEmpty(userContent)) {
+          result.push({ role: 'user', content: userContent });
         }
         continue;
       }
@@ -369,10 +387,13 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
       }
 
       // ── Plain message (User/Assistant/System) ────────────────────────
-      result.push({
-        role: this.mapRole(msg.role),
-        content: this.convertToChatMessageContent(msg.content),
-      });
+      const convertedContent = this.convertToChatMessageContent(msg.content);
+      if (!this.isContentEmpty(convertedContent)) {
+        result.push({
+          role: this.mapRole(msg.role),
+          content: convertedContent,
+        });
+      }
     }
 
     return result;
@@ -407,6 +428,16 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
     }
 
     return parts;
+  }
+
+  private isContentEmpty(content: string | ChatMessageContentPart[] | null): boolean {
+    if (!content) return true;
+    if (typeof content === 'string') return content.trim().length === 0;
+    if (Array.isArray(content)) {
+      if (content.length === 0) return true;
+      return content.every(part => part.type === 'text' && part.text.trim().length === 0);
+    }
+    return false;
   }
 
   /**

--- a/src/lmstudio-provider.ts
+++ b/src/lmstudio-provider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { LMStudioClient } from './lmstudio-client';
-import { LMStudioModel, ChatMessage, ChatTool } from './types';
+import { LMStudioModel, ChatMessage, ChatTool, ChatMessageContentPart } from './types';
 
 /**
  * Information about an LM Studio model for VS Code
@@ -89,12 +89,12 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
       name: this.formatModelName(model.id),
       family: 'lmstudio',
       version: '1.0.0',
-      maxInputTokens,
+      maxInputTokens: model.max_context_length || maxInputTokens,
       maxOutputTokens,
       lmstudioModelId: model.id,
       capabilities: {
         toolCalling: enableToolCalling,
-        imageInput: false,
+        imageInput: model.capabilities?.vision ?? false,
       },
     }));
   }
@@ -310,6 +310,7 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
    *   - LanguageModelTextPart → plain text
    *   - LanguageModelToolCallPart → an assistant's tool call request
    *   - LanguageModelToolResultPart → the result of a tool execution
+   *   - LanguageModelDataPart → an image or other binary data (for vision models)
    *
    * We flat-map because one VS Code message may expand into multiple OpenAI
    * messages (e.g. a user message with tool results → one "tool" message per result).
@@ -367,14 +368,45 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
         }
       }
 
-      // ── Plain message ────────────────────────────────────────────────
+      // ── Plain message (User/Assistant/System) ────────────────────────
       result.push({
         role: this.mapRole(msg.role),
-        content: this.extractMessageContent(msg),
+        content: this.convertToChatMessageContent(msg.content),
       });
     }
 
     return result;
+  }
+
+  /**
+   * Convert VS Code message content parts to OpenAI-compatible content.
+   * Handles text and images (vision).
+   */
+  private convertToChatMessageContent(
+    content: string | readonly any[]
+  ): string | ChatMessageContentPart[] {
+    if (typeof content === 'string') return content;
+
+    const parts: ChatMessageContentPart[] = [];
+    for (const part of content) {
+      if (part instanceof vscode.LanguageModelTextPart) {
+        parts.push({ type: 'text', text: part.value });
+      } else if (part instanceof vscode.LanguageModelDataPart && part.mimeType.startsWith('image/')) {
+        const base64 = Buffer.from(part.data).toString('base64');
+        parts.push({
+          type: 'image_url',
+          image_url: { url: `data:${part.mimeType};base64,${base64}` }
+        });
+      }
+    }
+
+    // If it's just one text part, return it as a string for better compatibility
+    // with models that don't fully support the array-of-parts format for plain text.
+    if (parts.length === 1 && parts[0].type === 'text') {
+      return parts[0].text;
+    }
+
+    return parts;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,10 +61,17 @@ export interface ModelsResponse {
 export interface ChatMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
   // null is required by OpenAI spec when the assistant message only contains tool_calls
-  content: string | null;
+  content: string | ChatMessageContentPart[] | null;
   tool_call_id?: string;
   tool_calls?: ToolCall[];
 }
+
+/**
+ * Content part for multi-modal messages
+ */
+export type ChatMessageContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: { url: string } };
 
 /**
  * Tool definition for function calling


### PR DESCRIPTION
 This PR addresses several edge cases and bugs identified in the multi-modal
  (vision) support:
   - Empty Content Handling: Added isContentEmpty to filter out messages that
     don't contain meaningful text or images, ensuring compliance with
     OpenAI-compatible APIs.
   - Robust Sanitization: sanitizeOutgoingContent now trims and filters out
     empty text parts within multi-modal arrays.
   - Improved Tool Result Logic: convertMessages now uses
     convertToChatMessageContent when processing content accompanying tool
     results, enabling images to be sent alongside tool results.
   - Accurate Token Counting: provideTokenCount now handles multi-modal
     arrays and includes a heuristic (1000 tokens) for images.
   - Message Filtering: normalizeOutgoingMessages now filters out empty
     messages entirely rather than sending empty content.