### PR TITLE
Add support for remote LM Studio servers, disable CLI for non-localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Run local LM Studio models inside VS Code Copilot Chat with streaming responses, tool calling, and optional image generation.
 
-If LM Studio is installed on your machine, the extension is designed to work out of the box.
+If LM Studio is installed on your machine, the extension is designed to work out of the box. It also supports connecting to remote LM Studio servers.
 
 Install from the VS Code Marketplace:
 
@@ -12,13 +12,15 @@ Install from the VS Code Marketplace:
 
 - Adds LM Studio models to the Copilot Chat model picker
 - Streams responses directly into VS Code chat
-- Can auto-start LM Studio and lazy-load the selected model on first use
+- Can auto-start LM Studio and lazy-load the selected model on first use (when using localhost)
+- Supports remote LM Studio servers without local CLI dependencies
 
 ## Requirements
 
 - VS Code 1.104.0 or later
-- LM Studio installed locally
-- LM Studio local server available at `http://localhost:1234` unless you changed it
+- LM Studio server accessible at the configured URL (default: `http://localhost:1234`)
+- For local usage: LM Studio installed on your machine
+- For remote usage: Access to a running LM Studio server on another machine
 
 ## Quick Start
 
@@ -27,13 +29,23 @@ Install from the VS Code Marketplace:
 3. Pick an LM Studio model.
 4. Send a prompt.
 
-No separate CLI install, PATH setup, or manual model preload should be required.
+No separate CLI install, PATH setup, or manual model preload should be required for local setups.
+
+## Remote Server Usage
+
+You can connect to an LM Studio server running on a remote machine:
+
+1. Set `lmstudio-copilot.serverUrl` to the remote server's URL (e.g., `http://your-server:1234`).
+2. Ensure the remote server is running and accessible.
+3. When using a remote server, local CLI features (auto-start, model discovery via CLI) are automatically disabled to avoid attempting to control the remote instance.
+
+This is useful for setups where LM Studio runs on a dedicated server or in a container.
 
 ## About The CLI
 
 You do not need to install the LM Studio CLI separately.
 
-The CLI ships with LM Studio, and the extension will try to find it automatically.
+The CLI ships with LM Studio, and the extension will try to find it automatically for local installations.
 
 The extension tries to find the CLI in this order:
 
@@ -41,7 +53,7 @@ The extension tries to find the CLI in this order:
 - `lms` on `PATH`
 - common LM Studio install locations
 
-For most users, nothing needs to be configured here.
+For most users, nothing needs to be configured here. CLI features are skipped when using remote servers.
 
 ## Important Settings
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,6 +71,11 @@ export async function activate(context: vscode.ExtensionContext) {
   const ensureServerRunning = async (): Promise<boolean> => {
     outputChannel.appendLine('Ensuring LM Studio server is running...');
 
+    if (!client.isLocalServerUrl()) {
+      outputChannel.appendLine('Remote server configured; skipping local CLI auto-start and terminal fallback');
+      return await client.checkConnection();
+    }
+
     const startedViaCli = await client.ensureServerRunning();
     if (startedViaCli) {
       outputChannel.appendLine('✅ LM Studio server is reachable');
@@ -113,6 +118,11 @@ export async function activate(context: vscode.ExtensionContext) {
   // Register commands
   context.subscriptions.push(
     vscode.commands.registerCommand('lmstudio-copilot.startServer', async () => {
+      if (!client.isLocalServerUrl()) {
+        vscode.window.showWarningMessage('Configured LM Studio server is remote; start it on the remote host instead of using the local CLI.');
+        return;
+      }
+
       const started = await ensureServerRunning();
       if (started) {
         vscode.window.showInformationMessage('LM Studio server is running');
@@ -123,6 +133,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('lmstudio-copilot.stopServer', async () => {
+      if (!client.isLocalServerUrl()) {
+        vscode.window.showWarningMessage('Configured LM Studio server is remote; stop it on the remote host instead of using the local CLI.');
+        return;
+      }
+
       const stopped = await client.stopServer();
       if (stopped) {
         lmStudioTerminal?.dispose();

--- a/src/lmstudio-client.ts
+++ b/src/lmstudio-client.ts
@@ -187,7 +187,7 @@ export class LMStudioClient {
     }
   }
 
-  private isLocalServerUrl(): boolean {
+  public isLocalServerUrl(): boolean {
     const url = this.parseServerUrl();
     if (!url) {
       return false;
@@ -301,6 +301,11 @@ export class LMStudioClient {
   }
 
   async getInstalledModels(): Promise<LMStudioModel[]> {
+    if (!this.isLocalServerUrl()) {
+      this.log('Skipping local `lms ls` because the configured server URL is not local');
+      return [];
+    }
+
     const rawModels = await this.execLmsJson<LMStudioLocalModel[]>(['ls', '--json'], this.getConfig().requestTimeout);
     if (!Array.isArray(rawModels)) {
       return [];
@@ -327,6 +332,12 @@ export class LMStudioClient {
   }
 
   async getLoadedModelIds(): Promise<Set<string>> {
+    if (!this.isLocalServerUrl()) {
+      this.log('Skipping local `lms ps` because the configured server URL is not local');
+      const liveModels = await this.getModels();
+      return new Set(liveModels.map((model) => model.id));
+    }
+
     const rawModels = await this.execLmsJson<LMStudioLocalModel[]>(['ps', '--json'], this.getConfig().requestTimeout);
     if (!Array.isArray(rawModels)) {
       return new Set<string>();
@@ -375,6 +386,11 @@ export class LMStudioClient {
   }
 
   async stopServer(): Promise<boolean> {
+    if (!this.isLocalServerUrl()) {
+      this.log('Skipping local CLI stop because the configured server URL is not local');
+      return false;
+    }
+
     const result = await this.execLms(['server', 'stop'], 30000);
     if (result.exitCode !== 0) {
       return false;
@@ -385,6 +401,16 @@ export class LMStudioClient {
   }
 
   async ensureModelLoaded(modelId: string): Promise<boolean> {
+    if (!this.isLocalServerUrl()) {
+      const serverReady = await this.checkConnection();
+      if (!serverReady) {
+        this.log(`Cannot load model ${modelId} because the LM Studio server is unavailable`);
+        return false;
+      }
+
+      return this.waitForModelAvailability(modelId, Math.max(this.getConfig().requestTimeout, 10 * 60 * 1000));
+    }
+
     const serverReady = await this.ensureServerRunning();
     if (!serverReady) {
       this.log(`Cannot load model ${modelId} because the LM Studio server is unavailable`);


### PR DESCRIPTION
- Disable local CLI features when server URL is not localhost/127.0.0.1
- Skip auto-start, CLI model discovery, and lazy-loading for remote servers
- Update README with remote server usage instructions
- Improve error handling for remote setups