### PR TITLE
Fix VS Code 1.120 model picker visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Fix LM Studio models not appearing in the VS Code 1.120 model picker by marking discovered models as user-selectable.
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/src/lmstudio-provider.ts
+++ b/src/lmstudio-provider.ts
@@ -8,6 +8,7 @@ import { LMStudioModel, ChatMessage, ChatTool, ChatMessageContentPart } from './
 interface LMStudioModelInfo extends vscode.LanguageModelChatInformation {
   lmstudioModelId: string;
   isLoaded: boolean;
+  isUserSelectable: boolean;
 }
 
 /**
@@ -123,6 +124,7 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
       maxOutputTokens,
       lmstudioModelId: model.id,
       isLoaded: Boolean(model.loaded),
+      isUserSelectable: true,
       capabilities: {
         toolCalling: enableToolCalling,
         imageInput: model.capabilities?.vision ?? false,


### PR DESCRIPTION
Fixes #14.

VS Code 1.120 filters language model chat providers from the model picker unless returned models are explicitly marked as user selectable.

This PR adds `isUserSelectable: true` to each discovered LM Studio model and documents the fix in the changelog.

Tested with:

```bash
npm run compile
```