### PR TITLE
Switch to control output logging in Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ dist/
 .vscode-test/
 .snapshots/
 .env
-
-
 #Ignore vscode AI rules
 .github/instructions/codacy.instructions.md
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,5 @@
     "**/dist/**": true,
     "**/assets/tmp/**": true,
     "**/*.vsix": true
-  },
-  "lmstudio-copilot.logLevel": "none"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
     "**/dist/**": true,
     "**/assets/tmp/**": true,
     "**/*.vsix": true
-  }
+  },
+  "lmstudio-copilot.logLevel": "none"
 }

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ Most users can leave the defaults alone. These are the settings that matter most
 - `lmstudio-copilot.maxTools`: Limit the number of tools exposed per request
 - `lmstudio-copilot.imageGenEndpointUrl`: Base URL for DALL-E/OpenAI-compatible or A1111 image generation
 - `lmstudio-copilot.imageGenApiKey`: Dedicated API key for image generation backends such as OpenAI DALL-E
-- `lmstudio-copilot.logLevel`: default is verbose which is the standard level of logging to Output.
-                                Set it to none to turn off all logging to Output 
+- `lmstudio-copilot.logLevel`: Controls output logging verbosity. Default is `verbose`; set to `info`, `warning`, `error`, or `none`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Most users can leave the defaults alone. These are the settings that matter most
 - `lmstudio-copilot.maxTools`: Limit the number of tools exposed per request
 - `lmstudio-copilot.imageGenEndpointUrl`: Base URL for DALL-E/OpenAI-compatible or A1111 image generation
 - `lmstudio-copilot.imageGenApiKey`: Dedicated API key for image generation backends such as OpenAI DALL-E
+- `lmstudio-copilot.logLevel`: default is verbose which is the standard level of logging to Output.
+                                Set it to none to turn off all logging to Output 
 
 ## Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lmstudio-copilot-provider",
-  "version": "0.1.27",
+  "version": "0.1.28-JG",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lmstudio-copilot-provider",
-      "version": "0.1.27",
+      "version": "0.1.28-JG",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lmstudio-copilot-provider",
   "displayName": "LM Studio for Copilot Chat",
   "description": "Use local LM Studio models inside VS Code Copilot Chat with streaming, tool calling, and optional image generation.",
-  "version": "0.1.27",
+  "version": "0.1.28-JG",
   "publisher": "DanLambiase",
   "license": "MIT",
   "repository": {
@@ -40,6 +40,20 @@
         "title": "LM Studio",
         "order": 1,
         "properties": {
+          "lmstudio-copilot.logLevel": {
+            "type": "string",
+            "enum": ["verbose", "info", "warning", "error", "none"],
+            "enumDescriptions": [
+              "All messages including detailed diagnostics",
+              "State changes, model discovery, and important events",
+              "Warnings and errors only",
+              "Errors only",
+              "No Output Channel logging"
+            ],
+            "default": "verbose",
+            "order": 0,
+            "description": "Controls how much diagnostic information is written to the LM Studio output channel"
+          },
           "lmstudio-copilot.serverUrl": {
             "type": "string",
             "default": "http://localhost:1234",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { LMStudioProvider } from './lmstudio-provider';
 import { LMStudioClient } from './lmstudio-client';
+import { Logger } from './logger';
 import { registerAllTools } from './tools/index';
 
 let provider: LMStudioProvider | undefined;
@@ -16,12 +17,16 @@ export async function activate(context: vscode.ExtensionContext) {
   // Create output channel for logging
   outputChannel = vscode.window.createOutputChannel('LM Studio Provider');
   context.subscriptions.push(outputChannel);
-  
-  outputChannel.appendLine(`LM Studio Copilot Provider is activating... v${context.extension.packageJSON.version}`);
-  outputChannel.show(true);
 
-  const client = new LMStudioClient(outputChannel);
-  provider = new LMStudioProvider(client, context, outputChannel);
+  const logger = new Logger(outputChannel);
+
+  logger.info(`LM Studio Copilot Provider is activating... v${context.extension.packageJSON.version}`);
+  if (logger.shouldShow) {
+    outputChannel.show(true);
+  }
+
+  const client = new LMStudioClient(logger);
+  provider = new LMStudioProvider(client, context, logger);
 
   const getOrCreateTerminalByName = (terminalName: string): vscode.Terminal => {
     const existing = vscode.window.terminals.find((t) => t.name === terminalName);
@@ -45,8 +50,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
     if (!launchCommand) {
       const message = 'LM Studio CLI auto-start is unavailable and no fallback launch command is configured.';
-      outputChannel.appendLine(`⚠️ ${message}`);
-      outputChannel.appendLine('   If LM Studio is already running, you can ignore this message.');
+      logger.warn(`⚠️ ${message}`);
+      logger.warn('   If LM Studio is already running, you can ignore this message.');
       if (!silent) {
         vscode.window.showWarningMessage(message);
       }
@@ -55,7 +60,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const terminal = getOrCreateServerTerminal();
     terminal.show(true);
-    outputChannel.appendLine(`Starting LM Studio server in terminal with command: ${launchCommand}`);
+    logger.info(`Starting LM Studio server in terminal with command: ${launchCommand}`);
     terminal.sendText(launchCommand, true);
 
     const startupWaitMs = config.get<number>('startupWaitMs', 3000);
@@ -63,29 +68,29 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const connected = await client.checkConnection();
     if (connected) {
-      outputChannel.appendLine('✅ LM Studio server appears reachable after terminal launch');
+      logger.info('✅ LM Studio server appears reachable after terminal launch');
       return true;
     }
 
-    outputChannel.appendLine('⚠️ LM Studio server not reachable yet after terminal launch');
+    logger.warn('⚠️ LM Studio server not reachable yet after terminal launch');
     return false;
   };
 
   const ensureServerRunning = async (silent = false): Promise<boolean> => {
-    outputChannel.appendLine('Ensuring LM Studio server is running...');
+    logger.info('Ensuring LM Studio server is running...');
 
     if (!client.isLocalServerUrl()) {
-      outputChannel.appendLine('Remote server configured; skipping local CLI auto-start and terminal fallback');
+      logger.info('Remote server configured; skipping local CLI auto-start and terminal fallback');
       return await client.checkConnection();
     }
 
     const startedViaCli = await client.ensureServerRunning();
     if (startedViaCli) {
-      outputChannel.appendLine('✅ LM Studio server is reachable');
+      logger.info('✅ LM Studio server is reachable');
       return true;
     }
 
-    outputChannel.appendLine('CLI-based auto-start unavailable, trying launchCommand fallback');
+    logger.info('CLI-based auto-start unavailable, trying launchCommand fallback');
     return startServerInTerminal(silent);
   };
 
@@ -99,7 +104,7 @@ export async function activate(context: vscode.ExtensionContext) {
       return;
     }
 
-    outputChannel.appendLine(`Stopping LM Studio terminal: ${terminal.name}`);
+    logger.info(`Stopping LM Studio terminal: ${terminal.name}`);
     terminal.dispose();
     lmStudioTerminal = undefined;
     vscode.window.showInformationMessage('LM Studio terminal stopped.');
@@ -109,14 +114,14 @@ export async function activate(context: vscode.ExtensionContext) {
   try {
     registration = vscode.lm.registerLanguageModelChatProvider('lmstudio', provider);
     context.subscriptions.push(registration);
-    outputChannel.appendLine('✅ Provider registered successfully with vendor: lmstudio');
+    logger.info('✅ Provider registered successfully with vendor: lmstudio');
   } catch (error) {
-    outputChannel.appendLine(`❌ Failed to register provider: ${error}`);
+    logger.error(`❌ Failed to register provider: ${error}`);
     vscode.window.showErrorMessage(`Failed to register LM Studio provider: ${error}`);
   }
 
   // Register all LM tools (terminal, read_file, write_file, list_directory, search_files)
-  registerAllTools(context, outputChannel);
+  registerAllTools(context, logger);
 
   // Register commands
   context.subscriptions.push(
@@ -155,7 +160,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('lmstudio-copilot.refreshModels', async () => {
-      outputChannel.appendLine('Refreshing models...');
+      logger.info('Refreshing models...');
       await provider?.refreshModels();
       vscode.window.showInformationMessage('LM Studio models refreshed');
     })
@@ -166,10 +171,10 @@ export async function activate(context: vscode.ExtensionContext) {
       const connected = await client.checkConnection();
       if (connected) {
         vscode.window.showInformationMessage('✅ Connected to LM Studio server');
-        outputChannel.appendLine('✅ Connection check: OK');
+        logger.info('✅ Connection check: OK');
       } else {
         vscode.window.showErrorMessage('❌ Cannot connect to LM Studio server. Make sure it is running.');
-        outputChannel.appendLine('❌ Connection check: FAILED');
+        logger.error('❌ Connection check: FAILED');
       }
     })
   );
@@ -178,7 +183,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration('lmstudio-copilot')) {
-        outputChannel.appendLine('Configuration changed, refreshing models...');
+        logger.info('Configuration changed, refreshing models...');
         provider?.refreshModels();
       }
     })
@@ -187,16 +192,16 @@ export async function activate(context: vscode.ExtensionContext) {
   // Auto-refresh models on startup if enabled
   const config = vscode.workspace.getConfiguration('lmstudio-copilot');
   if (config.get<boolean>('autoStartServer', true)) {
-    outputChannel.appendLine('Auto-start server enabled, ensuring LM Studio is running...');
+    logger.info('Auto-start server enabled, ensuring LM Studio is running...');
     await ensureServerRunning(true);
   }
 
   if (config.get<boolean>('autoRefreshModels', true)) {
-    outputChannel.appendLine('Auto-refresh enabled, refreshing models now...');
+    logger.info('Auto-refresh enabled, refreshing models now...');
     await provider?.refreshModels();
   }
 
-  outputChannel.appendLine(`LM Studio Copilot Provider activated v${context.extension.packageJSON.version}`);
+  logger.info(`LM Studio Copilot Provider activated v${context.extension.packageJSON.version}`);
 }
 
 export function deactivate() {

--- a/src/lmstudio-client.ts
+++ b/src/lmstudio-client.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as cp from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
+import { Logger } from './logger';
 import {
   LMStudioConfig,
   LMStudioLocalModel,
@@ -43,10 +44,10 @@ export class LMStudioClient {
   private abortControllers = new Map<string, AbortController>();
   private resolvedCliPath: string | null | undefined;
 
-  constructor(private outputChannel?: vscode.OutputChannel) {}
+  constructor(private logger: Logger) {}
 
   private log(msg: string): void {
-    this.outputChannel?.appendLine(`[Client] ${msg}`);
+    this.logger.verbose(`[Client] ${msg}`);
   }
 
   private getConfig(): LMStudioConfig {

--- a/src/lmstudio-client.ts
+++ b/src/lmstudio-client.ts
@@ -50,6 +50,14 @@ export class LMStudioClient {
     this.logger.verbose(`[Client] ${msg}`);
   }
 
+  private warn(msg: string): void {
+    this.logger.warn(`[Client] ${msg}`);
+  }
+
+  private error(msg: string): void {
+    this.logger.error(`[Client] ${msg}`);
+  }
+
   private getConfig(): LMStudioConfig {
     return getConfig();
   }
@@ -135,7 +143,7 @@ export class LMStudioClient {
     this.log(`CLI: ${cliPath} ${args.join(' ')}`);
     const result = await this.execFileAsync(cliPath, args, timeoutMs);
     if (result.exitCode !== 0) {
-      this.log(`CLI command failed (${result.exitCode}): ${result.stderr || result.stdout}`);
+      this.error(`CLI command failed (${result.exitCode}): ${result.stderr || result.stdout}`);
     }
     return result;
   }
@@ -154,7 +162,7 @@ export class LMStudioClient {
     try {
       return JSON.parse(text) as T;
     } catch (error) {
-      this.log(`Failed to parse CLI JSON for "${args.join(' ')}": ${error}`);
+      this.warn(`Failed to parse CLI JSON for "${args.join(' ')}": ${error}`);
       return null;
     }
   }
@@ -174,7 +182,7 @@ export class LMStudioClient {
       this.log(`Spawned detached CLI process: ${cliPath} ${args.join(' ')}`);
       return true;
     } catch (error) {
-      this.log(`Failed to spawn detached CLI process: ${error}`);
+      this.error(`Failed to spawn detached CLI process: ${error}`);
       return false;
     }
   }
@@ -183,7 +191,7 @@ export class LMStudioClient {
     try {
       return new URL(this.getConfig().serverUrl);
     } catch (error) {
-      this.log(`Invalid server URL: ${error}`);
+      this.error(`Invalid server URL: ${error}`);
       return null;
     }
   }
@@ -252,7 +260,7 @@ export class LMStudioClient {
       this.log(`Connection check: ${r.status}`);
       return r.ok;
     } catch (e) {
-      this.log(`Connection check failed: ${e}`);
+      this.error(`Connection check failed: ${e}`);
       return false;
     }
   }
@@ -296,7 +304,7 @@ export class LMStudioClient {
       this.log(`Found ${models.length} models: ${models.map(m => m.id).join(', ')}`);
       return models;
     } catch (e) {
-      this.log(`Error fetching models: ${e}`);
+      this.error(`Error fetching models: ${e}`);
       return [];
     }
   }
@@ -405,7 +413,7 @@ export class LMStudioClient {
     if (!this.isLocalServerUrl()) {
       const serverReady = await this.checkConnection();
       if (!serverReady) {
-        this.log(`Cannot load model ${modelId} because the LM Studio server is unavailable`);
+        this.error(`Cannot load model ${modelId} because the LM Studio server is unavailable`);
         return false;
       }
 
@@ -414,7 +422,7 @@ export class LMStudioClient {
 
     const serverReady = await this.ensureServerRunning();
     if (!serverReady) {
-      this.log(`Cannot load model ${modelId} because the LM Studio server is unavailable`);
+      this.error(`Cannot load model ${modelId} because the LM Studio server is unavailable`);
       return false;
     }
 

--- a/src/lmstudio-provider.ts
+++ b/src/lmstudio-provider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { LMStudioClient } from './lmstudio-client';
+import { Logger } from './logger';
 import { LMStudioModel, ChatMessage, ChatTool, ChatMessageContentPart } from './types';
 
 /**
@@ -52,13 +53,13 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
   constructor(
     private client: LMStudioClient,
     private context: vscode.ExtensionContext,
-    private outputChannel?: vscode.OutputChannel
+    private logger: Logger
   ) {
     this.disposables.push(this._onDidChangeLanguageModelChatInformation);
   }
 
   private log(msg: string): void {
-    this.outputChannel?.appendLine(`[Provider] ${msg}`);
+    this.logger.verbose(`[Provider] ${msg}`);
   }
 
   // ──────────────────────────────────────────────────────────────────────

--- a/src/lmstudio-provider.ts
+++ b/src/lmstudio-provider.ts
@@ -62,6 +62,14 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
     this.logger.verbose(`[Provider] ${msg}`);
   }
 
+  private warn(msg: string): void {
+    this.logger.warn(`[Provider] ${msg}`);
+  }
+
+  private error(msg: string): void {
+    this.logger.error(`[Provider] ${msg}`);
+  }
+
   // ──────────────────────────────────────────────────────────────────────
   // Model discovery
   // ──────────────────────────────────────────────────────────────────────
@@ -261,7 +269,7 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
           try {
             parsedArgs = JSON.parse(tc.function.arguments || '{}');
           } catch (e) {
-            this.log(`Tool call "${tc.function.name}" has invalid JSON args: ${tc.function.arguments}`);
+            this.warn(`Tool call "${tc.function.name}" has invalid JSON args: ${tc.function.arguments}`);
             parsedArgs = {};
           }
 
@@ -274,7 +282,7 @@ export class LMStudioProvider implements vscode.LanguageModelChatProvider<LMStud
         }
       }
     } catch (error) {
-      this.log(`Streaming error: ${error}`);
+      this.error(`Streaming error: ${error}`);
       if (!token.isCancellationRequested) throw error;
     }
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,64 @@
+import * as vscode from 'vscode';
+
+export type LogLevel = 'verbose' | 'info' | 'warning' | 'error' | 'none';
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  verbose: 0,
+  info: 1,
+  warning: 2,
+  error: 3,
+  none: 4,
+};
+
+/**
+ * Wraps a VS Code OutputChannel with level-gated logging.
+ *
+ * Reads `lmstudio-copilot.logLevel` from VS Code settings on every call,
+ * so the user can change it at runtime without reloading the extension.
+ */
+export class Logger {
+  constructor(private channel: vscode.OutputChannel) {}
+
+  private get configuredLevel(): LogLevel {
+    return vscode.workspace
+      .getConfiguration('lmstudio-copilot')
+      .get<LogLevel>('logLevel', 'verbose');
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    return LEVEL_ORDER[level] >= LEVEL_ORDER[this.configuredLevel];
+  }
+
+  /** Detailed diagnostic output — suppressed at 'info' and above. */
+  verbose(msg: string): void {
+    if (this.shouldLog('verbose')) {
+      this.channel.appendLine(msg);
+    }
+  }
+
+  /** State changes, model discovery, important events. */
+  info(msg: string): void {
+    if (this.shouldLog('info')) {
+      this.channel.appendLine(msg);
+    }
+  }
+
+  /** Warnings about fallbacks, unavailability, etc. */
+  warn(msg: string): void {
+    if (this.shouldLog('warning')) {
+      this.channel.appendLine(msg);
+    }
+  }
+
+  /** Errors — always logged unless level is 'none'. */
+  error(msg: string): void {
+    if (this.shouldLog('error')) {
+      this.channel.appendLine(msg);
+    }
+  }
+
+  /** Whether the output channel should be revealed on startup. */
+  get shouldShow(): boolean {
+    return this.configuredLevel !== 'none';
+  }
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,13 @@
 import * as vscode from 'vscode';
 
 export type LogLevel = 'verbose' | 'info' | 'warning' | 'error' | 'none';
+const VALID_LOG_LEVELS: ReadonlySet<LogLevel> = new Set<LogLevel>([
+  'verbose',
+  'info',
+  'warning',
+  'error',
+  'none',
+]);
 
 const LEVEL_ORDER: Record<LogLevel, number> = {
   verbose: 0,
@@ -20,9 +27,15 @@ export class Logger {
   constructor(private channel: vscode.OutputChannel) {}
 
   private get configuredLevel(): LogLevel {
-    return vscode.workspace
+    const configuredValue = vscode.workspace
       .getConfiguration('lmstudio-copilot')
-      .get<LogLevel>('logLevel', 'verbose');
+      .get<string>('logLevel', 'verbose');
+
+    if (VALID_LOG_LEVELS.has(configuredValue as LogLevel)) {
+      return configuredValue as LogLevel;
+    }
+
+    return 'verbose';
   }
 
   private shouldLog(level: LogLevel): boolean {

--- a/src/tools/file-tools.ts
+++ b/src/tools/file-tools.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as cp from 'child_process';
+import { Logger } from '../logger';
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -50,7 +51,7 @@ interface ReadFileInput {
 }
 
 export function createReadFileTool(
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): vscode.LanguageModelTool<ReadFileInput> {
   return {
     prepareInvocation: (options) => ({
@@ -59,7 +60,7 @@ export function createReadFileTool(
 
     invoke: async (options) => {
       const resolved = resolvePath(options.input.path);
-      outputChannel.appendLine(`[read_file] ${resolved}`);
+      logger.verbose(`[read_file] ${resolved}`);
 
       if (!fs.existsSync(resolved)) {
         return makeResult(`File not found: ${resolved}`);
@@ -103,7 +104,7 @@ interface WriteFileInput {
 }
 
 export function createWriteFileTool(
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): vscode.LanguageModelTool<WriteFileInput> {
   return {
     prepareInvocation: (options) => ({
@@ -112,7 +113,7 @@ export function createWriteFileTool(
 
     invoke: async (options) => {
       const resolved = resolvePath(options.input.path);
-      outputChannel.appendLine(`[write_file] ${resolved}`);
+      logger.verbose(`[write_file] ${resolved}`);
 
       try {
         if (options.input.createDirectories !== false) {
@@ -201,7 +202,7 @@ function listDir(
 }
 
 export function createListDirectoryTool(
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): vscode.LanguageModelTool<ListDirectoryInput> {
   return {
     prepareInvocation: (options) => ({
@@ -210,7 +211,7 @@ export function createListDirectoryTool(
 
     invoke: async (options) => {
       const dirPath = resolvePath(options.input.path ?? '.');
-      outputChannel.appendLine(`[list_directory] ${dirPath}`);
+      logger.verbose(`[list_directory] ${dirPath}`);
 
       if (!fs.existsSync(dirPath)) {
         return makeResult(`Directory not found: ${dirPath}`);
@@ -412,7 +413,7 @@ async function searchManually(
 }
 
 export function createSearchFilesTool(
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): vscode.LanguageModelTool<SearchFilesInput> {
   return {
     prepareInvocation: (options) => ({
@@ -431,7 +432,7 @@ export function createSearchFilesTool(
       const isRegex = options.input.isRegex ?? false;
       const caseSensitive = options.input.caseSensitive ?? false;
 
-      outputChannel.appendLine(
+      logger.verbose(
         `[search_files] pattern="${pattern}" regex=${isRegex} case=${caseSensitive} max=${maxResults}`
       );
 

--- a/src/tools/image-tool.ts
+++ b/src/tools/image-tool.ts
@@ -614,7 +614,7 @@ export function createImageGenTool(
           imageBytes = await generateDalle(options.input, config, abortController.signal, logger);
         }
       } catch (e) {
-        logger.verbose(`[generate_image] ERROR: ${e}`);
+        logger.error(`[generate_image] ERROR: ${e}`);
         return makeResult(`Image generation failed: ${e}`);
       }
 
@@ -626,7 +626,7 @@ export function createImageGenTool(
         fs.writeFileSync(savePath, imageBytes);
         logger.verbose(`[generate_image] Saved to: ${savePath}`);
       } catch (e) {
-        logger.verbose(`[generate_image] Save failed: ${e}`);
+        logger.warn(`[generate_image] Save failed: ${e}`);
       }
 
       // Open the saved file in VS Code if saving succeeded

--- a/src/tools/image-tool.ts
+++ b/src/tools/image-tool.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { Logger } from '../logger';
 
 export const IMAGE_GEN_TOOL_NAME = 'lmstudio_generate_image';
 
@@ -85,7 +86,7 @@ function formatDalleError(rawText: string, model: string, availableModels: strin
 async function fetchAvailableDalleModels(
   config: Config,
   signal: AbortSignal,
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): Promise<string[]> {
   const modelsUrl = joinEndpointUrl(config.endpointUrl, '/v1/models');
   const headers: Record<string, string> = {};
@@ -94,7 +95,7 @@ async function fetchAvailableDalleModels(
   }
 
   try {
-    outputChannel.appendLine(`[generate_image] GET ${modelsUrl}`);
+    logger.verbose(`[generate_image] GET ${modelsUrl}`);
     const response = await fetch(modelsUrl, {
       method: 'GET',
       headers,
@@ -102,7 +103,7 @@ async function fetchAvailableDalleModels(
     });
 
     if (!response.ok) {
-      outputChannel.appendLine(
+      logger.verbose(
         `[generate_image] Model discovery failed with status ${response.status}`
       );
       return [];
@@ -116,7 +117,7 @@ async function fetchAvailableDalleModels(
       ?.map((entry) => entry.id?.trim())
       .filter((id): id is string => Boolean(id)) ?? [];
   } catch (error) {
-    outputChannel.appendLine(`[generate_image] Model discovery failed: ${error}`);
+    logger.verbose(`[generate_image] Model discovery failed: ${error}`);
     return [];
   }
 }
@@ -124,7 +125,7 @@ async function fetchAvailableDalleModels(
 async function resolveDalleModel(
   config: Config,
   signal: AbortSignal,
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): Promise<string | undefined> {
   if (config.model) {
     return config.model;
@@ -134,9 +135,9 @@ async function resolveDalleModel(
     return DEFAULT_DALLE_MODEL;
   }
 
-  const availableModels = await fetchAvailableDalleModels(config, signal, outputChannel);
+  const availableModels = await fetchAvailableDalleModels(config, signal, logger);
   if (availableModels.length === 1) {
-    outputChannel.appendLine(
+    logger.verbose(
       `[generate_image] Auto-selected sole available image model: ${availableModels[0]}`
     );
     return availableModels[0];
@@ -252,7 +253,7 @@ function snapToSupportedSize(
   width: number,
   height: number,
   supported: [number, number][],
-  outputChannel: vscode.OutputChannel,
+  logger: Logger,
   label: string
 ): string {
   const requested = `${width}x${height}`;
@@ -272,7 +273,7 @@ function snapToSupportedSize(
   }
 
   const snapped = `${best[0]}x${best[1]}`;
-  outputChannel.appendLine(
+  logger.verbose(
     `[generate_image] Requested size ${requested} is not supported by ${label}; using ${snapped}.`
   );
   return snapped;
@@ -308,20 +309,20 @@ function chooseInitialDalleSize(
   model: string | undefined,
   width: number,
   height: number,
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): string | undefined {
   if (model?.toLowerCase().includes('gpt-image-1') && isOpenAiImagesEndpoint(endpointUrl)) {
-    outputChannel.appendLine(
+    logger.verbose(
       '[generate_image] Omitting size for gpt-image-1 on OpenAI.'
     );
     return undefined;
   }
 
   if (isOpenAiImagesEndpoint(endpointUrl)) {
-    return snapOpenAiSize(model, width, height, outputChannel);
+    return snapOpenAiSize(model, width, height, logger);
   }
 
-  outputChannel.appendLine(
+  logger.verbose(
     '[generate_image] Using initial size=auto for non-OpenAI image endpoint.'
   );
   return 'auto';
@@ -331,7 +332,7 @@ function snapOpenAiSize(
   model: string | undefined,
   width: number,
   height: number,
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): string {
   const requested = `${width}x${height}`;
   const supported = getOpenAiSizesForModel(model);
@@ -339,7 +340,7 @@ function snapOpenAiSize(
     return requested;
   }
 
-  return snapToSupportedSize(width, height, supported, outputChannel, model ?? 'OpenAI image API');
+  return snapToSupportedSize(width, height, supported, logger, model ?? 'OpenAI image API');
 }
 
 async function postDalleRequest(
@@ -347,10 +348,10 @@ async function postDalleRequest(
   headers: Record<string, string>,
   body: Record<string, unknown>,
   signal: AbortSignal,
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): Promise<{ response: Response; rawText: string }> {
-  outputChannel.appendLine(`[generate_image] POST ${generationsUrl}`);
-  outputChannel.appendLine(`[generate_image] Request body: ${JSON.stringify(body)}`);
+  logger.verbose(`[generate_image] POST ${generationsUrl}`);
+  logger.verbose(`[generate_image] Request body: ${JSON.stringify(body)}`);
 
   const response = await fetch(generationsUrl, {
     method: 'POST',
@@ -360,7 +361,7 @@ async function postDalleRequest(
   });
 
   const rawText = await response.text();
-  outputChannel.appendLine(`[generate_image] Response ${response.status}: ${rawText.slice(0, 500)}`);
+  logger.verbose(`[generate_image] Response ${response.status}: ${rawText.slice(0, 500)}`);
   return { response, rawText };
 }
 
@@ -368,20 +369,20 @@ async function generateDalle(
   input: ImageGenInput,
   config: Config,
   signal: AbortSignal,
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): Promise<Uint8Array> {
   const generationsUrl = joinEndpointUrl(config.endpointUrl, '/v1/images/generations');
   // Always honor the user's configured size; ignore any width/height the model
   // tries to pass via tool input (OpenAI image endpoints only accept a fixed set).
   const width = config.defaultWidth;
   const height = config.defaultHeight;
-  const model = await resolveDalleModel(config, signal, outputChannel);
+  const model = await resolveDalleModel(config, signal, logger);
   const size = chooseInitialDalleSize(
     config.endpointUrl,
     model,
     width,
     height,
-    outputChannel
+    logger
   );
   const initialSize = size;
 
@@ -411,7 +412,7 @@ async function generateDalle(
     headers,
     body,
     signal,
-    outputChannel
+    logger
   );
 
   if (!response.ok && isInvalidImageSizeError(rawText)) {
@@ -425,12 +426,12 @@ async function generateDalle(
           width,
           height,
           supportedSizes,
-          outputChannel,
+          logger,
           'image API response'
         );
 
     if (retrySize !== String(body.size)) {
-      outputChannel.appendLine(
+      logger.verbose(
         `[generate_image] Retrying after invalid size response with size=${retrySize}.`
       );
       body.size = retrySize;
@@ -439,18 +440,18 @@ async function generateDalle(
         headers,
         body,
         signal,
-        outputChannel
+        logger
       ));
     }
   }
 
   if (!response.ok) {
-    outputChannel.appendLine(
+    logger.verbose(
       `[generate_image] Final DALL-E failure after size handling. model=${model ?? '<unspecified>'} size=${String(body.size)}`
     );
     const availableModels =
       /"param"\s*:\s*"model"/i.test(rawText) && /"code"\s*:\s*"invalid_value"/i.test(rawText)
-        ? await fetchAvailableDalleModels(config, signal, outputChannel)
+        ? await fetchAvailableDalleModels(config, signal, logger)
         : [];
     throw new Error(
       `Request meta: model=${model ?? '<unspecified>'} initialSize=${initialSize ?? '<omitted>'} finalSize=${String(body.size ?? '<omitted>')} configuredWidth=${width} configuredHeight=${height}. ${formatDalleError(rawText, model ?? '<unspecified>', availableModels)} (HTTP ${response.status})`
@@ -473,7 +474,7 @@ async function generateDalle(
   }
 
   if (first?.url) {
-    outputChannel.appendLine(`[generate_image] Fetching image from URL: ${first.url}`);
+    logger.verbose(`[generate_image] Fetching image from URL: ${first.url}`);
     const imgResponse = await fetch(first.url, { signal });
     if (!imgResponse.ok) {
       throw new Error(`Failed to fetch image from URL ${first.url}: ${imgResponse.status}`);
@@ -561,7 +562,7 @@ function resolveSavePath(input: ImageGenInput, config: Config): string {
 }
 
 export function createImageGenTool(
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): vscode.LanguageModelTool<ImageGenInput> {
   return {
     prepareInvocation: (options) => ({
@@ -572,7 +573,7 @@ export function createImageGenTool(
       const config = getConfig();
       const { prompt } = options.input;
 
-      outputChannel.appendLine(
+      logger.verbose(
         `[generate_image] resolved config: backend=${config.backend} model=${config.model || '<unset>'} endpoint=${config.endpointUrl} width=${config.defaultWidth} height=${config.defaultHeight}`
       );
 
@@ -590,15 +591,15 @@ export function createImageGenTool(
       const endpointIsEmpty = !config.endpointUrl.trim();
       const urlLower = config.endpointUrl.toLowerCase();
       const isLmStudioUrl = LMSTUDIO_HOSTS.some((h) => urlLower.includes(h));
-      outputChannel.appendLine(
+      logger.verbose(
         `[generate_image] config: backend="${config.backend}" endpointUrl="${config.endpointUrl}" empty=${endpointIsEmpty} isLmStudio=${isLmStudioUrl}`
       );
       if (endpointIsEmpty || isLmStudioUrl) {
-        outputChannel.appendLine('[generate_image] No valid image gen endpoint configured — returning setup help');
+        logger.verbose('[generate_image] No valid image gen endpoint configured — returning setup help');
         return makeResult(SETUP_HELP);
       }
 
-      outputChannel.appendLine(
+      logger.verbose(
         `[generate_image] backend=${config.backend} prompt="${prompt.slice(0, 100)}"`
       );
 
@@ -610,22 +611,22 @@ export function createImageGenTool(
         if (config.backend === 'a1111') {
           imageBytes = await generateA1111(options.input, config, abortController.signal);
         } else {
-          imageBytes = await generateDalle(options.input, config, abortController.signal, outputChannel);
+          imageBytes = await generateDalle(options.input, config, abortController.signal, logger);
         }
       } catch (e) {
-        outputChannel.appendLine(`[generate_image] ERROR: ${e}`);
+        logger.verbose(`[generate_image] ERROR: ${e}`);
         return makeResult(`Image generation failed: ${e}`);
       }
 
-      outputChannel.appendLine(`[generate_image] Generated ${imageBytes.length} bytes`);
+      logger.verbose(`[generate_image] Generated ${imageBytes.length} bytes`);
 
       // Save to disk
       const savePath = resolveSavePath(options.input, config);
       try {
         fs.writeFileSync(savePath, imageBytes);
-        outputChannel.appendLine(`[generate_image] Saved to: ${savePath}`);
+        logger.verbose(`[generate_image] Saved to: ${savePath}`);
       } catch (e) {
-        outputChannel.appendLine(`[generate_image] Save failed: ${e}`);
+        logger.verbose(`[generate_image] Save failed: ${e}`);
       }
 
       // Open the saved file in VS Code if saving succeeded

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { Logger } from '../logger';
 import { TERMINAL_TOOL_NAME, createTerminalTool } from './terminal-tool';
 import {
   READ_FILE_TOOL_NAME,
@@ -27,18 +28,18 @@ export {
  */
 export function registerAllTools(
   context: vscode.ExtensionContext,
-  outputChannel: vscode.OutputChannel
+  logger: Logger
 ): void {
   context.subscriptions.push(
-    vscode.lm.registerTool(TERMINAL_TOOL_NAME, createTerminalTool(outputChannel)),
-    vscode.lm.registerTool(READ_FILE_TOOL_NAME, createReadFileTool(outputChannel)),
-    vscode.lm.registerTool(WRITE_FILE_TOOL_NAME, createWriteFileTool(outputChannel)),
-    vscode.lm.registerTool(LIST_DIRECTORY_TOOL_NAME, createListDirectoryTool(outputChannel)),
-    vscode.lm.registerTool(SEARCH_FILES_TOOL_NAME, createSearchFilesTool(outputChannel)),
-    vscode.lm.registerTool(IMAGE_GEN_TOOL_NAME, createImageGenTool(outputChannel))
+    vscode.lm.registerTool(TERMINAL_TOOL_NAME, createTerminalTool(logger)),
+    vscode.lm.registerTool(READ_FILE_TOOL_NAME, createReadFileTool(logger)),
+    vscode.lm.registerTool(WRITE_FILE_TOOL_NAME, createWriteFileTool(logger)),
+    vscode.lm.registerTool(LIST_DIRECTORY_TOOL_NAME, createListDirectoryTool(logger)),
+    vscode.lm.registerTool(SEARCH_FILES_TOOL_NAME, createSearchFilesTool(logger)),
+    vscode.lm.registerTool(IMAGE_GEN_TOOL_NAME, createImageGenTool(logger))
   );
 
-  outputChannel.appendLine(
+  logger.info(
     `✅ Registered LM tools: ${
       [
         TERMINAL_TOOL_NAME,

--- a/src/tools/terminal-tool.ts
+++ b/src/tools/terminal-tool.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
+import { Logger } from '../logger';
 
 export const TERMINAL_TOOL_NAME = 'lmstudio_run_in_terminal';
 
@@ -53,7 +54,7 @@ function makeResult(text: string): vscode.LanguageModelToolResult {
   return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(text)]);
 }
 
-export function createTerminalTool(outputChannel: vscode.OutputChannel): vscode.LanguageModelTool<TerminalToolInput> {
+export function createTerminalTool(logger: Logger): vscode.LanguageModelTool<TerminalToolInput> {
   return {
     prepareInvocation: (options) => ({
       invocationMessage: `Running: ${options.input.command}`,
@@ -79,7 +80,7 @@ export function createTerminalTool(outputChannel: vscode.OutputChannel): vscode.
       }
 
       const cwd = options.input.cwd?.trim() || getWorkspaceCwd();
-      outputChannel.appendLine(`[run_in_terminal] cwd=${cwd}  cmd=${command}`);
+      logger.verbose(`[run_in_terminal] cwd=${cwd}  cmd=${command}`);
 
       // Show the command in the named terminal so the user can follow along
       // Only reuse a terminal that is still alive (exitStatus === undefined means it hasn't exited)
@@ -90,7 +91,7 @@ export function createTerminalTool(outputChannel: vscode.OutputChannel): vscode.
 
       // Execute with real output capture
       const { stdout, stderr, exitCode } = await execAsync(command, cwd, timeoutMs);
-      outputChannel.appendLine(
+      logger.verbose(
         `[run_in_terminal] exit=${exitCode}  stdout=${stdout.length}b  stderr=${stderr.length}b`
       );
 


### PR DESCRIPTION
Added a switch Log Level (lmstudio-copilot.logLevel) to control how much logging goes to the Output tab. Default is verbose which keeps existing logging as is. Set it to none to turn off all logging.
