### PR TITLE
Refine Gemma channel filtering logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
             "type": "string",
             "enum": [
               "default",
+              "none",
               "low",
               "medium",
               "high"

--- a/src/lmstudio-client.ts
+++ b/src/lmstudio-client.ts
@@ -490,8 +490,11 @@ export class LMStudioClient {
 
     const reasoningEffort = clientConfig.get<string>('reasoningEffort', 'default');
     if (reasoningEffort !== 'default') {
-      body.reasoning_effort = reasoningEffort as 'low' | 'medium' | 'high';
+      body.reasoning_effort = reasoningEffort as 'none' | 'low' | 'medium' | 'high';
       this.log(`reasoning_effort=${reasoningEffort} (user setting)`);
+    } else if (!enableThinking) {
+      body.reasoning_effort = 'none';
+      this.log("reasoning_effort=none (derived from enableThinking=false)");
     }
     if (options.tools?.length) {
       body.tools = options.tools;

--- a/src/lmstudio-client.ts
+++ b/src/lmstudio-client.ts
@@ -764,7 +764,7 @@ export class LMStudioClient {
    * Hides thought/analysis channels while preserving function-call channels.
    */
   private filterGemmaChannelContent(raw: string, state: GemmaChannelState): string {
-    const channelTokenRe = /<\|?channel\|?>\s*([^\n<]*)/gi;
+    const channelTokenRe = /(<channel\|>)|(<\|channel\|>|<\|channel>)\s*([^\n<]*)/gi;
     let buf = state.pending + raw;
     state.pending = '';
 
@@ -780,11 +780,14 @@ export class LMStudioClient {
         output += before;
       }
 
-      const rawLabel = (match[1] ?? '').trim();
+      const isMalformedClose = Boolean(match[1]);
+      const rawLabel = (isMalformedClose ? '' : match[3] ?? '').trim();
       const label = rawLabel.toLowerCase();
 
       // Preserve function channels so downstream legacy tool parser can still decode calls.
-      if (label.startsWith('to=functions/')) {
+      if (isMalformedClose) {
+        state.insideThought = false;
+      } else if (label.startsWith('to=functions/')) {
         state.insideThought = false;
         output += matchText;
       } else if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,7 @@ export interface ChatCompletionRequest {
   /** Qwen3 / thinking models: set false to skip generating a reasoning trace */
   enable_thinking?: boolean;
   /** OpenAI-style reasoning effort hint for models that support it (e.g. o1, o3, QwQ) */
-  reasoning_effort?: 'low' | 'medium' | 'high';
+  reasoning_effort?: 'none' |'low' | 'medium' | 'high';
 }
 
 /**


### PR DESCRIPTION
Improve the regex and state handling for Gemma's channel tokens to more accurately distinguish between malformed closing tags and actual channel labels. This ensures that the `insideThought` state is correctly updated even when encountering malformed tags, while preserving the visibility of function-call channels.<

Add a new `none` value to the `reasoning_effort` enum in both the type definitions and package configuration, and adjust the client logic so that when `enableThinking` is false or the setting is default, the request body uses `'none'`. This enables explicit disabling of reasoning traces for models that support it (i.e Gemma).